### PR TITLE
Fix incorrect path to notebooks/ in docs/README_CN and docs/README_JP

### DIFF
--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -146,7 +146,7 @@ training_config "为训练设置, "model_config "为模型设置，"dataset_conf
 # 如何使用
 
 您可以从 HuggingFace Hub 下载训练好的模型：[turing-motors/heron-chat-git-ja-stablelm-base-7b-v0](https://huggingface.co/turing-motors/heron-chat-git-ja-stablelm-base-7b-v0)<br>
-有关推理和训练方法的更多信息, 请参阅 [notebooks](./notebooks).
+有关推理和训练方法的更多信息, 请参阅 [notebooks](../notebooks).
 
 ```python
 import requests

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -145,7 +145,7 @@ dataset_config_path:
 # 利用方法
 
 HuggingFace Hubから学習済みモデルをダウンロードすることができます: [turing-motors/heron-chat-git-ja-stablelm-base-7b-v0](https://huggingface.co/turing-motors/heron-chat-git-ja-stablelm-base-7b-v0)<br>
-推論・学習の方法については[notebooks](./notebooks)も参考にしてください。
+推論・学習の方法については[notebooks](../notebooks)も参考にしてください。
 
 ```python
 import requests


### PR DESCRIPTION
## Pull Request Title

### Description

**Purpose of the PR**
- notebooks/ directory in the docs/README_CN.md and docs/README_JP.md files. The existing paths were written as `./notebooks` but should be `../notebooks`.

**Related Issue(s)**
- N/A

### Changes

- Corrected the notebook directory reference from `./notebooks` to `../notebooks` in docs/README_CN.md.
- Corrected the notebook directory reference from `./notebooks` to `../notebooks` in docs/README_JP.md.

### Model/Algorithm Performance

- N/A (This PR does not involve changes to models or algorithms.)

### Dependencies

- No new dependencies were introduced.

### Reviewer Notes

- Please review the changed paths in both README files to confirm that they now correctly point to the notebooks/ directory.

### Confirmed

- [x] I have updated the documentation accordingly.
- [x] I have adhered to the coding standards and guidelines of this project.
- [x] I have added comments, especially in hard-to-understand areas.
