### PR TITLE
fix: git_llm from_pretrained now works correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ print(processor.tokenizer.batch_decode(out)[0])
 |[heron-chat-blip-ja-stablelm-base-7b-v0](https://huggingface.co/turing-motors/heron-chat-blip-ja-stablelm-base-7b-v0)|Japanese StableLM Base Alpha|BLIP|7B|
 |[heron-chat-git-ja-stablelm-base-7b-v0](https://huggingface.co/turing-motors/heron-chat-git-ja-stablelm-base-7b-v0)|Japanese StableLM Base Alpha|GIT|7B|
 |[heron-chat-git-ELYZA-fast-7b-v0](https://huggingface.co/turing-motors/heron-chat-git-ELYZA-fast-7b-v0)|ELYZA|GIT|7B|
+|[heron-chat-git-Llama-2-7b-v0](https://huggingface.co/turing-motors/heron-chat-git-Llama-2-7b-v0)|Llama-2|GIT|7B|
 |[heron-preliminary-git-Llama-2-70b-v0](https://huggingface.co/turing-motors/heron-preliminary-git-Llama-2-70b-v0) *1|Llama-2|GIT|70B|
 *1 This model only applies to pre-training of adapters.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ from PIL import Image
 
 import torch
 from transformers import AutoProcessor
-from heron.models.git_llm.git_llama import GitLlamaConfig, GitLlamaForCausalLM
+from heron.models.git_llm.git_llama import GitLlamaForCausalLM
 
 device_id = 0
 

--- a/README.md
+++ b/README.md
@@ -154,23 +154,25 @@ from PIL import Image
 
 import torch
 from transformers import AutoProcessor
-from heron.models.git_llm.git_llama import GitLlamaForCausalLM
+from heron.models.git_llm.git_llama import GitLlamaConfig, GitLlamaForCausalLM
 
 device_id = 0
 
 # prepare a pretrained model
-model = GitLlamaForCausalLM.from_pretrained('turing-motors/heron-chat-git-ja-stablelm-base-7b-v0')
+model = GitLlamaForCausalLM.from_pretrained(
+    'turing-motors/heron-chat-git-Llama-2-7b-v0', torch_dtype=torch.float16
+)
 model.eval()
 model.to(f"cuda:{device_id}")
 
 # prepare a processor
-processor = AutoProcessor.from_pretrained('turing-motors/heron-chat-git-ja-stablelm-base-7b-v0')
+processor = AutoProcessor.from_pretrained('turing-motors/heron-chat-git-Llama-2-7b-v0')
 
 # prepare inputs
 url = "https://www.barnorama.com/wp-content/uploads/2016/12/03-Confusing-Pictures.jpg"
 image = Image.open(requests.get(url, stream=True).raw)
 
-text = f"##Instruction: Please answer the following question concretely. ##Question: What is unusual about this image? Explain precisely and concretely what he is doing? ##Answer: "
+text = f"##human: What is this picture?\n##gpt: "
 
 # do preprocessing
 inputs = processor(
@@ -192,7 +194,7 @@ with torch.no_grad():
     out = model.generate(**inputs, max_length=256, do_sample=False, temperature=0., eos_token_id=eos_token_id_list)
 
 # print result
-print(processor.tokenizer.batch_decode(out))
+print(processor.tokenizer.batch_decode(out)[0])
 ```
 
 ### Pretrained Models

--- a/heron/models/git_llm/git_gpt_neox/modeling_git_gpt_neox.py
+++ b/heron/models/git_llm/git_gpt_neox/modeling_git_gpt_neox.py
@@ -44,8 +44,11 @@ class GitGPTNeoXConfig(GPTNeoXConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.vision_config = CLIPVisionConfig()
-        self.num_image_with_embedding = None
+        if hasattr(self, "vision_model_name"):
+            self.set_vision_configs(self.num_image_with_embedding, self.vision_model_name)
+        else:
+            self.vision_config = CLIPVisionConfig()
+            self.num_image_with_embedding = None
 
     def set_vision_configs(
         self,

--- a/heron/models/git_llm/git_japanese_stablelm_alpha/modeling_git_japanese_stablelm_alpha.py
+++ b/heron/models/git_llm/git_japanese_stablelm_alpha/modeling_git_japanese_stablelm_alpha.py
@@ -44,8 +44,11 @@ class GitJapaneseStableLMAlphaConfig(JapaneseStableLMAlphaConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.vision_config = CLIPVisionConfig()
-        self.num_image_with_embedding = None
+        if hasattr(self, "vision_model_name"):
+            self.set_vision_configs(self.num_image_with_embedding, self.vision_model_name)
+        else:
+            self.vision_config = CLIPVisionConfig()
+            self.num_image_with_embedding = None
 
     def set_vision_configs(
         self,

--- a/heron/models/git_llm/git_llama/modeling_git_llama.py
+++ b/heron/models/git_llm/git_llama/modeling_git_llama.py
@@ -44,8 +44,11 @@ class GitLlamaConfig(LlamaConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.vision_config = CLIPVisionConfig()
-        self.num_image_with_embedding = None
+        if hasattr(self, "vision_model_name"):
+            self.set_vision_configs(self.num_image_with_embedding, self.vision_model_name)
+        else:
+            self.vision_config = CLIPVisionConfig()
+            self.num_image_with_embedding = None
 
     def set_vision_configs(
         self,

--- a/heron/models/git_llm/git_mpt/modeling_git_mpt.py
+++ b/heron/models/git_llm/git_mpt/modeling_git_mpt.py
@@ -53,8 +53,11 @@ class GitMptConfig(MptConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.vision_config = CLIPVisionConfig()
-        self.num_image_with_embedding = None
+        if hasattr(self, "vision_model_name"):
+            self.set_vision_configs(self.num_image_with_embedding, self.vision_model_name)
+        else:
+            self.vision_config = CLIPVisionConfig()
+            self.num_image_with_embedding = None
 
     def set_vision_configs(
         self,

--- a/heron/models/git_llm/git_opt/modeling_git_opt.py
+++ b/heron/models/git_llm/git_opt/modeling_git_opt.py
@@ -45,8 +45,11 @@ class GitOPTConfig(OPTConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.vision_config = CLIPVisionConfig()
-        self.num_image_with_embedding = None
+        if hasattr(self, "vision_model_name"):
+            self.set_vision_configs(self.num_image_with_embedding, self.vision_model_name)
+        else:
+            self.vision_config = CLIPVisionConfig()
+            self.num_image_with_embedding = None
 
     def set_vision_configs(
         self,


### PR DESCRIPTION
## Fix loading GIT-LLM pretrained weight from Hugging Face repo.

### Description

**Purpose of the PR**
- There are errors in git_llm configs when loading from pretrained model. So, fix it.

**Related Issue(s)**
- Nothing.

### Changes

- All git_config classes are initialized by the saved config.
- Change a README evaluation example.
- Add GIT-Llama2 English to pretrained mdels list in the README.

- ...

### Model/Algorithm Performance

- Nothing

### Dependencies

- Nothing.

### Reviewer Notes

- I checked the model is correctly loaded from Hugging Face repo, and the evaluation example can run successfully.

### Confirmed

- [x] I have updated the documentation accordingly.
- [x] I have adhered to the coding standards and guidelines of this project.
- [x] I have added comments, especially in hard-to-understand areas.
