### PR TITLE
Enable Multi Layer Perceptron (MLP) selection for projector

### DIFF
--- a/heron/models/git_llm/git_gpt_neox/modeling_git_gpt_neox.py
+++ b/heron/models/git_llm/git_gpt_neox/modeling_git_gpt_neox.py
@@ -33,7 +33,7 @@ from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     CausalLMOutputWithPast,
 )
-from transformers.models.git.modeling_git import GitProjection
+from heron.models.mlp_adapter import MLPProjection
 
 
 class GitGPTNeoXConfig(GPTNeoXConfig):
@@ -95,7 +95,7 @@ class GitGPTNeoXModel(GPTNeoXModel):
 
         # Git modules
         self.image_encoder = CLIPVisionModel.from_pretrained(config.vision_model_name)
-        self.visual_projection = GitProjection(config)
+        self.visual_projection = MLPProjection(config)
 
         if config.num_image_with_embedding is not None:
             self.img_temporal_embedding = nn.ParameterList(

--- a/heron/models/git_llm/git_japanese_stablelm_alpha/modeling_git_japanese_stablelm_alpha.py
+++ b/heron/models/git_llm/git_japanese_stablelm_alpha/modeling_git_japanese_stablelm_alpha.py
@@ -27,7 +27,7 @@ from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     CausalLMOutputWithPast,
 )
-from transformers.models.git.modeling_git import GitProjection
+from heron.models.mlp_adapter import MLPProjection
 
 from .configuration_japanese_stablelm_alpha import JapaneseStableLMAlphaConfig
 from .modeling_japanese_stablelm_alpha import (
@@ -95,7 +95,7 @@ class GitJapaneseStableLMAlphaModel(JapaneseStableLMAlphaModel):
 
         # Git modules
         self.image_encoder = CLIPVisionModel.from_pretrained(config.vision_model_name)
-        self.visual_projection = GitProjection(config)
+        self.visual_projection = MLPProjection(config)
 
         if config.num_image_with_embedding is not None:
             self.img_temporal_embedding = nn.ParameterList(

--- a/heron/models/git_llm/git_llama/modeling_git_llama.py
+++ b/heron/models/git_llm/git_llama/modeling_git_llama.py
@@ -33,7 +33,7 @@ from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     CausalLMOutputWithPast,
 )
-from transformers.models.git.modeling_git import GitProjection
+from heron.models.mlp_adapter import MLPProjection
 
 
 class GitLlamaConfig(LlamaConfig):
@@ -95,7 +95,7 @@ class GitLlamaModel(LlamaModel):
 
         # Git modules
         self.image_encoder = CLIPVisionModel.from_pretrained(config.vision_model_name)
-        self.visual_projection = GitProjection(config)
+        self.visual_projection = MLPProjection(config)
 
         if config.num_image_with_embedding is not None:
             self.img_temporal_embedding = nn.ParameterList(

--- a/heron/models/git_llm/git_mpt/modeling_git_mpt.py
+++ b/heron/models/git_llm/git_mpt/modeling_git_mpt.py
@@ -42,7 +42,7 @@ from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     CausalLMOutputWithPast,
 )
-from transformers.models.git.modeling_git import GitProjection
+from heron.models.mlp_adapter import MLPProjection
 
 
 class GitMptConfig(MptConfig):
@@ -105,7 +105,7 @@ class GitMptModel(MptModel):
 
         # Git modules
         self.image_encoder = CLIPVisionModel.from_pretrained(config.vision_model_name)
-        self.visual_projection = GitProjection(config)
+        self.visual_projection = MLPProjection(config)
 
         if config.num_image_with_embedding is not None:
             self.img_temporal_embedding = nn.ParameterList(

--- a/heron/models/git_llm/git_opt/modeling_git_opt.py
+++ b/heron/models/git_llm/git_opt/modeling_git_opt.py
@@ -33,7 +33,7 @@ from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
     CausalLMOutputWithPast,
 )
-from transformers.models.git.modeling_git import GitProjection
+from heron.models.mlp_adapter import MLPProjection
 from transformers.models.opt.modeling_opt import OPTLearnedPositionalEmbedding
 
 
@@ -96,7 +96,7 @@ class GitOPTModel(OPTModel):
 
         # Git modules
         self.image_encoder = CLIPVisionModel.from_pretrained(config.vision_model_name)
-        self.visual_projection = GitProjection(config)
+        self.visual_projection = MLPProjection(config)
 
         if config.num_image_with_embedding is not None:
             self.img_temporal_embedding = nn.ParameterList(

--- a/heron/models/mlp_adapter.py
+++ b/heron/models/mlp_adapter.py
@@ -1,0 +1,29 @@
+import re
+import torch
+import torch.nn as nn
+from transformers.models.git.modeling_git import GitProjection
+
+class MLPProjection(GitProjection):
+    def __init__(self, config):
+        super(MLPProjection, self).__init__(config)
+        self.config = config
+
+        if hasattr(config, "mlp_adapter"):
+            mlp_gelu_match = re.match(r'^mlp(\d+)x_gelu$', config.mlp_adapter)
+            if mlp_gelu_match:
+                mlp_depth = int(mlp_gelu_match.group(1))
+                modules = [nn.Linear(config.vision_config.hidden_size, config.hidden_size)]
+                for _ in range(1, mlp_depth):
+                    modules.append(nn.GELU())
+                    modules.append(nn.Linear(config.hidden_size, config.hidden_size))
+                modules.append(nn.LayerNorm(config.hidden_size, eps=config.vision_config.layer_norm_eps))
+            else:
+                raise ValueError(f'Unknown mlp_adapter name: {config.mlp_adapter}')
+        else:
+            modules = [nn.Linear(config.vision_config.hidden_size, config.hidden_size)]
+            modules.append(nn.LayerNorm(config.hidden_size, eps=config.vision_config.layer_norm_eps))
+
+        self.visual_projection = nn.Sequential(*modules)
+
+    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+        return self.visual_projection(embeddings)

--- a/heron/models/utils.py
+++ b/heron/models/utils.py
@@ -31,6 +31,10 @@ def load_model(
     model_type = model_config["model_type"]
     language_model = model_config["language_model_name"]
     num_image_with_embedding = model_config["num_image_with_embedding"]
+    if "mlp_adapter" in model_config:
+        adapter_name = model_config["mlp_adapter"]
+    else:
+        adapter_name = "linear"
 
     # set dtype
     if model_config.get("fp16", False):
@@ -47,6 +51,7 @@ def load_model(
                 num_image_with_embedding=num_image_with_embedding,
                 vision_model_name=model_config["vision_model_name"],
             )
+            git_config.mlp_adapter = adapter_name
             model = GitOPTForCausalLM.from_pretrained(
                 language_model, config=git_config, torch_dtype=torch_dtype
             )
@@ -59,6 +64,7 @@ def load_model(
                 num_image_with_embedding=num_image_with_embedding,
                 vision_model_name=model_config["vision_model_name"],
             )
+            git_config.mlp_adapter = adapter_name
             model = GitLlamaForCausalLM.from_pretrained(
                 language_model, config=git_config, torch_dtype=torch_dtype
             )
@@ -71,6 +77,7 @@ def load_model(
                 num_image_with_embedding=num_image_with_embedding,
                 vision_model_name=model_config["vision_model_name"],
             )
+            git_config.mlp_adapter = adapter_name
             model = GitMptForCausalLM.from_pretrained(
                 language_model, config=git_config, torch_dtype=torch_dtype
             )
@@ -86,6 +93,7 @@ def load_model(
                 num_image_with_embedding=num_image_with_embedding,
                 vision_model_name=model_config["vision_model_name"],
             )
+            git_config.mlp_adapter = adapter_name
             model = GitJapaneseStableLMAlphaForCausalLM.from_pretrained(
                 language_model, config=git_config, torch_dtype=torch_dtype
             )
@@ -102,6 +110,7 @@ def load_model(
                 num_image_with_embedding=num_image_with_embedding,
                 vision_model_name=model_config["vision_model_name"],
             )
+            git_config.mlp_adapter = adapter_name
             model = GitGPTNeoXForCausalLM.from_pretrained(
                 language_model, config=git_config, torch_dtype=torch_dtype
             )


### PR DESCRIPTION
## Enable Multi Layer Perceptron (MLP) selection for projector

First of all, thank you for creating such an amazing project! 
This repository has become very useful for me.

### Changes

Now, I have made a modification to the code to allow the projector to be a Multi Layer Perceptron (MLP) when `model_type: git_llm` is selected.
Previously, when using `model_type: git_llm`, a single Linear layer was applied as the projector that connects the Vision model and the LLM. However, inspired by LLaVA v1.5 【[Liu+'23 Improved Baselines with Visual Instruction Tuning](https://arxiv.org/abs/2310.03744)】, I have added code that makes it possible to vary the number of these Linear layers simply by adding an option (`mlp_adapter`) in `projects/OOO/OO.yml` under `model_config`.
The main details of the code for changing the projector to an MLP can be understood by looking at `heron/models/mlp_adapter.py`. 
Furthermore, this code references the github implementation of LLaVA v1.5 ( https://github.com/haotian-liu/LLaVA/blob/785f766fcddc86ffeaa62cd51cf7834a11c04e6d/llava/model/multimodal_projector/builder.py#L33 ).

Also, to maintain compatibility, I've made sure it works the same way as before with the existing `projects/OOO/OO.yml`.

For example, if you use `projects/llama/exp001.yml` as it is,

```
training_config:
  per_device_train_batch_size: 2
  gradient_accumulation_steps: 4
  num_train_epochs: 1
  dataloader_num_workers: 16
  fp16: true
  optim: "adamw_torch"
  learning_rate: 5.0e-5
  logging_steps: 100
  evaluation_strategy: "steps"
  save_strategy: "steps"
  eval_steps: 4000
  save_steps: 4000
  save_total_limit: 1
  deepspeed: ./configs/deepspeed/ds_config_zero1.json
  output_dir: ./output/
  report_to: "wandb"

model_config:
  fp16: true
  pretrained_path: # None or path to model weight
  model_type: git_llm
  language_model_name: meta-llama/Llama-2-7b-chat-hf
  vision_model_name: openai/clip-vit-base-patch16
  num_image_with_embedding: 1 # if 1, no img_temporal_embedding
  max_length: 512
  keys_to_finetune:
    - visual_projection
    - num_image_with_embedding
  keys_to_freeze: []

  use_lora: true
  lora:
    r: 8
    lora_alpha: 32
    target_modules:
      - q_proj
      - k_proj
      - v_proj
    lora_dropout: 0.01
    bias: none
    task_type: CAUSAL_LM

dataset_config_path:
  - ./configs/datasets/m3it.yaml
```

As before, a single layer Linear layer will be applied as the projector.

If you want to change the projector to an MLP, add the `mlp_adapter` item to `model_config` in `projects/llama/exp001.yml` and give it the name `mlp2x_gelu`.

```
training_config:
  per_device_train_batch_size: 2
  gradient_accumulation_steps: 4
  num_train_epochs: 1
  dataloader_num_workers: 16
  fp16: true
  optim: "adamw_torch"
  learning_rate: 5.0e-5
  logging_steps: 100
  evaluation_strategy: "steps"
  save_strategy: "steps"
  eval_steps: 4000
  save_steps: 4000
  save_total_limit: 1
  deepspeed: ./configs/deepspeed/ds_config_zero1.json
  output_dir: ./output/
  report_to: "wandb"

model_config:
  fp16: true
  pretrained_path: # None or path to model weight
  model_type: git_llm
  mlp_adapter: mlp2x_gelu # projector will be a 2-layer MLP.
  language_model_name: meta-llama/Llama-2-7b-chat-hf
  vision_model_name: openai/clip-vit-base-patch16
  num_image_with_embedding: 1 # if 1, no img_temporal_embedding
  max_length: 512
  keys_to_finetune:
    - visual_projection
    - num_image_with_embedding
  keys_to_freeze: []

  use_lora: true
  lora:
    r: 8
    lora_alpha: 32
    target_modules:
      - q_proj
      - k_proj
      - v_proj
    lora_dropout: 0.01
    bias: none
    task_type: CAUSAL_LM

dataset_config_path:
  - ./configs/datasets/m3it.yaml
```

In the above example, by adding `mlp_adapter: mlp2x_gelu` under `model_config`, the projector will become a 2-layer MLP, but if you want it to be 3 layers, simply changing to `mlp_adapter: mlp3x_gelu` will make it a 3-layer MLP easily!
