### PR TITLE
FIX: fix tokenizer loading in README to run examples correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ model.to(f"cuda:{device_id}")
 
 # prepare a processor
 processor = AutoProcessor.from_pretrained('turing-motors/heron-chat-git-ja-stablelm-base-7b-v1')
+tokenizer = LlamaTokenizer.from_pretrained(
+    "novelai/nerdstash-tokenizer-v1",
+    padding_side="right",
+    additional_special_tokens=["▁▁"],
+)
+processor.tokenizer = tokenizer
 
 # prepare inputs
 url = "https://www.barnorama.com/wp-content/uploads/2016/12/03-Confusing-Pictures.jpg"

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ import requests
 from PIL import Image
 
 import torch
-from transformers import AutoProcessor
+from transformers import AutoProcessor, LlamaTokenizer
 from heron.models.git_llm.git_japanese_stablelm_alpha import GitJapaneseStableLMAlphaForCausalLM
 
 device_id = 0

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -168,7 +168,7 @@ import requests
 from PIL import Image
 
 import torch
-from transformers import AutoProcessor
+from transformers import AutoProcessor, LlamaTokenizer
 from heron.models.git_llm.git_japanese_stablelm_alpha import GitJapaneseStableLMAlphaForCausalLM
 
 device_id = 0

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -182,6 +182,12 @@ model.to(f"cuda:{device_id}")
 
 # prepare a processor
 processor = AutoProcessor.from_pretrained('turing-motors/heron-chat-git-ja-stablelm-base-7b-v1')
+tokenizer = LlamaTokenizer.from_pretrained(
+    "novelai/nerdstash-tokenizer-v1",
+    padding_side="right",
+    additional_special_tokens=["▁▁"],
+)
+processor.tokenizer = tokenizer
 
 # prepare inputs
 url = "https://www.barnorama.com/wp-content/uploads/2016/12/03-Confusing-Pictures.jpg"

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -181,6 +181,12 @@ model.to(f"cuda:{device_id}")
 
 # prepare a processor
 processor = AutoProcessor.from_pretrained('turing-motors/heron-chat-git-ja-stablelm-base-7b-v1')
+tokenizer = LlamaTokenizer.from_pretrained(
+    "novelai/nerdstash-tokenizer-v1",
+    padding_side="right",
+    additional_special_tokens=["▁▁"],
+)
+processor.tokenizer = tokenizer
 
 # prepare inputs
 url = "https://www.barnorama.com/wp-content/uploads/2016/12/03-Confusing-Pictures.jpg"

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -167,7 +167,7 @@ import requests
 from PIL import Image
 
 import torch
-from transformers import AutoProcessor
+from transformers import AutoProcessor, LlamaTokenizer
 from heron.models.git_llm.git_japanese_stablelm_alpha import GitJapaneseStableLMAlphaForCausalLM
 
 device_id = 0


### PR DESCRIPTION
## Pull Request Title

### Description

- There is a bug in a README example code.

### Changes

- Load a Japanese StableLM alpha tokenzer in proper way.

### Model/Algorithm Performance

- None

### Dependencies

- None

### Reviewer Notes

- It worked well in my environment.

### Confirmed

- [x] I have updated the documentation accordingly.
- [x] I have adhered to the coding standards and guidelines of this project.
- [x] I have added comments, especially in hard-to-understand areas.
